### PR TITLE
Fix SIZE_PATTERN for interlaced video modes

### DIFF
--- a/xrandr_manager/executor.py
+++ b/xrandr_manager/executor.py
@@ -12,7 +12,7 @@ logger = getLogger("xrandr-manager")
 
 class XrandrExecutor:
     CONNECTED_PATTERN = re.compile(r"([a-zA-Z0-9-]*?)\sconnected\s")
-    SIZE_PATTERN = re.compile(r"(\d{3,4}x\d{3,4})\s+\d{2,3}.\d{2,3}")
+    SIZE_PATTERN = re.compile(r"(\d{3,4}x\d{3,4}i?)\s+\d{2,3}.\d{2,3}")
 
     @staticmethod
     def execute(command: str, is_dryrun: bool = True) -> None:


### PR DESCRIPTION
Got a `WARNING: Parse Error.` when running `xrandr-manager` on my machine:

```
❯ xrandr
Screen 0: minimum 320 x 200, current 5760 x 1600, maximum 16384 x 16384
eDP-1 connected 1920x1080+3840+0 (normal left inverted right x axis y axis) 309mm x 174mm
   1920x1080     60.05*+  60.01    59.97    59.96    59.93    40.03
   1680x1050     59.95    59.88
   1600x1024     60.17
   1400x1050     59.98
   1600x900      59.99    59.94    59.95    59.82
   1280x1024     60.02
   1440x900      59.89
   1400x900      59.96    59.88
   1280x960      60.00
   1440x810      60.00    59.97
   1368x768      59.88    59.85
   1360x768      59.80    59.96
   1280x800      59.99    59.97    59.81    59.91
   1152x864      60.00
   1280x720      60.00    59.99    59.86    59.74
   1024x768      60.04    60.00
   960x720       60.00
   928x696       60.05
   896x672       60.01
   1024x576      59.95    59.96    59.90    59.82
   960x600       59.93    60.00
   960x540       59.96    59.99    59.63    59.82
   800x600       60.00    60.32    56.25
   840x525       60.01    59.88
   864x486       59.92    59.57
   800x512       60.17
   700x525       59.98
   800x450       59.95    59.82
   640x512       60.02
   720x450       59.89
   700x450       59.96    59.88
   640x480       60.00    59.94
   720x405       59.51    58.99
   684x384       59.88    59.85
   680x384       59.80    59.96
   640x400       59.88    59.98
   576x432       60.06
   640x360       59.86    59.83    59.84    59.32
   512x384       60.00
   512x288       60.00    59.92
   480x270       59.63    59.82
   400x300       60.32    56.34
   432x243       59.92    59.57
   320x240       60.05
   360x202       59.51    59.13
   320x180       59.84    59.32
HDMI-1 connected primary 3840x1600+0+0 (normal left inverted right x axis y axis) 880mm x 367mm
   3840x1600     59.99 +  30.00*
   2560x1440     59.95
   2560x1080     60.00    59.94    59.98
   1920x1080     60.00    50.00    59.94
   1920x1080i    60.00    50.00    59.94
   1600x1200     60.00
   1280x1024     75.02    60.02
   1280x800      59.91
   1152x864      75.00
   1280x720      60.00    50.00    59.94
   1024x768      75.03    60.00
   800x600       75.00    60.32
   720x576       50.00
   720x576i      50.00
   720x480       60.00    59.94
   720x480i      60.00    59.94
   640x480       75.00    60.00    59.94
   720x400       70.08
DP-1 disconnected (normal left inverted right x axis y axis)
DP-2 disconnected (normal left inverted right x axis y axis)
DP-3 disconnected (normal left inverted right x axis y axis)
DP-4 disconnected (normal left inverted right x axis y axis)
```

```
name_list:
['eDP-1', 'HDMI-1']

size_list:
[
	['1920x1080', '1680x1050', '1600x1024', '1400x1050', '1600x900', '1280x1024', '1440x900', '1400x900', '1280x960', '1440x810', '1368x768', '1360x768', '1280x800', '1152x864', '1280x720', '1024x768', '960x720', '928x696', '896x672', '1024x576', '960x600', '960x540', '800x600', '840x525', '864x486', '800x512', '700x525', '800x450', '640x512', '720x450', '700x450', '640x480', '720x405', '684x384', '680x384', '640x400', '576x432', '640x360', '512x384', '512x288', '480x270', '400x300', '432x243', '320x240', '360x202', '320x180'],
	['3840x1600', '2560x1440', '2560x1080', '1920x1080'],
	['1600x1200', '1280x1024', '1280x800', '1152x864', '1280x720', '1024x768', '800x600', '720x576'],
	['720x480'],
	['640x480', '720x400']
]
```

Changing the `SIZE_PATTERN` to include interlaced video modes fixed it for me.